### PR TITLE
Fixed typecasting

### DIFF
--- a/src/middleware/validateBody.ts
+++ b/src/middleware/validateBody.ts
@@ -25,6 +25,7 @@ export function validateBody<T extends object>(
         ),
       });
     }
+    req.body = data;
     next();
   };
 }

--- a/src/models/News.ts
+++ b/src/models/News.ts
@@ -7,7 +7,7 @@ import {
 } from 'class-validator';
 import mongoose, { Schema } from 'mongoose';
 import { newsCategories } from '../constants/newsCategories';
-import { Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import 'reflect-metadata';
 import { INews } from '../interfaces/news';
 
@@ -27,7 +27,9 @@ export class NewsDto {
   @IsIn(newsCategories)
   category: string;
 
-  @Type(() => Boolean)
+  @Transform(({ value }) => {
+    return [true, 'true'].indexOf(value) > -1;
+  })
   @IsOptional()
   @IsBoolean()
   isBreakingNews: boolean;


### PR DESCRIPTION
`req.body` is now set to the value that is returned by class-transformer so that we can work with correct types. Also switched from `Type` to `Transform` because `isBreakingNews` gets sent as 'false' (string not boolean) which then actually results in `Type` returning true instead of false, which is not the expected behavior.